### PR TITLE
Rework channel code

### DIFF
--- a/TICC.ino
+++ b/TICC.ino
@@ -7,7 +7,6 @@
 // Portions Copyright George Byrkit K9TRV 2016
 // Licensed under BSD 2-clause license
 
-
 #include "TICC.h"     //Register and structure definitions
 
 // the TI TDC7200 communicates using SPI, so include the library:
@@ -16,23 +15,23 @@
 volatile unsigned long long coarseCount = 0;
 
 // Enumerate the TDC7200 channel structures
-static chanTDC7200 ChanA = {
-  .ID = 'A',
-  .ENABLE = ENABLE_A,
-  .INTB = INTB_A,
-  .CSB = CSB_A,
-  .STOP = STOP_A };
-
-static chanTDC7200 ChanB = {
-  .ID = 'B',
-  .ENABLE = ENABLE_B,
-  .INTB = INTB_B,
-  .CSB = CSB_B,
-  .STOP = STOP_B };
-
-chanTDC7200* ChA = &ChanA;  // pointer to Channel A
-chanTDC7200* ChB = &ChanB;
-
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+static struct chanTDC7200 channels[] = {
+  {
+    .ID = 'A',
+    .ENABLE = ENABLE_A,
+    .INTB = INTB_A,
+    .CSB = CSB_A,
+    .STOP = STOP_A
+  },
+  {
+    .ID = 'B',
+    .ENABLE = ENABLE_B,
+    .INTB = INTB_B,
+    .CSB = CSB_B,
+    .STOP = STOP_B
+  },
+};
 
 // properties of the TDC7200 chip:
 // Most Significant Bit is clocked first (MSBFIRST)
@@ -40,61 +39,53 @@ chanTDC7200* ChB = &ChanB;
 // data is clocked on the rising edge of the clock (seems to be SPI_MODE0)
 // max clock speed: 20 mHz
 // Using TDC7200 timing mode 1...
-
-
 void setup() {
+  int i;
   // start the SPI library:
   SPI.begin();
   
   pinMode(intPin, INPUT);
-  
-  pinMode(ChA->ENABLE,OUTPUT);
-  pinMode(ChA->INTB,INPUT);
-  pinMode(ChA->CSB,OUTPUT);
-  pinMode(ChA->STOP,INPUT);
-  pinMode(ChB->ENABLE,OUTPUT);
-  pinMode(ChB->INTB,INPUT);
-  pinMode(ChB->CSB,OUTPUT);
-  pinMode(ChB->STOP,INPUT);
+
+  for(i = 0; i < ARRAY_SIZE(channels); ++i) {
+    pinMode(channels[i].ENABLE,OUTPUT);
+    pinMode(channels[i].INTB,INPUT);
+    pinMode(channels[i].CSB,OUTPUT);
+    pinMode(channels[i].STOP,INPUT);
+    TDC_setup(&channels[i]);
+  }
   
   attachInterrupt(interrupt, coarseTimer, RISING);
-  
-  TDC_setup(ChA);
-  TDC_setup(ChB);
+
   delay(10);
-  ready_next(ChA);
-  ready_next(ChB);
+  
+  for(i = 0; i < ARRAY_SIZE(channels); ++i)
+      ready_next(&channels[i]);
   
   Serial.begin(115200);
   Serial.println("Starting...");
 }
 
 void loop() {
- 
-  if (ChA->STOP) 
-    ChA->stopTime = coarseCount; // capture time stamp of gated stop clock
- 
-  if (ChB->STOP) 
-    ChB->stopTime = coarseCount;
+  int i;
 
-  if (ChA->INTB) { // channel measurement complete
-    ChA->result = TDC_calc(ChA); // get registers and calc TOF
-    ready_next(ChA); // enable next measurement
+  for(i = 0; i < ARRAY_SIZE(channels); ++i) {
+    if(channels[i].STOP)
+      channels[i].stopTime = coarseCount;
+
+    if(channels[i].INTB) {
+      channels[i].result = TDC_calc(&channels[i]);
+      ready_next(&channels[i]);
+    }
   }
-  
-  if (ChB->INTB) {
-    ChB->result = TDC_calc(ChB);
-    ready_next(ChB);
-  }
-   
+     
    // if we have both channels, subtract channel 0 from channel 1, print result, and reset vars
-   if (ChanA.result && ChanB.result) { 
+  if (channels[0].result && channels[1].result) { 
     output_ti();
-    ChA->result = 0;
-    ChB->result = 0;
-    ChA->stopTime = 0;
-    ChB->stopTime = 0;
-   } 
+    for(i = 0; i < ARRAY_SIZE(channels); ++i) {
+      channels[i].result = 0;
+      channels[i].stopTime = 0;
+    }
+  }
 }  
 
 // ISR for timer. NOTE: uint_64 rollover would take
@@ -106,27 +97,26 @@ void coarseTimer() {
 
 // Initial config for TDC7200
 
-int TDC_setup(chanTDC7200* channel) {
+int TDC_setup(struct chanTDC7200 *channel) {
   digitalWrite(channel->ENABLE, HIGH);
 }
 
 
 // Fetch and calculate results from TDC7200
-int TDC_calc(chanTDC7200* channel) {
+int TDC_calc(struct chanTDC7200 *channel) {
     TDC_read(channel);
     // calc the values (John...)
 }
 
 // Read TDC for channel
-void TDC_read(chanTDC7200* channel) {
-
+void TDC_read(struct chanTDC7200 *channel) {
   byte inByte = 0;
   int timeResult = 0;
   int clockResult = 0;
   int calResult = 0;
 
   // read the TIMER1 register
-    // take the chip select low to select the device:
+  // take the chip select low to select the device:
   digitalWrite(channel->CSB, LOW);
 
   SPI.transfer(TIME1);
@@ -139,8 +129,8 @@ void TDC_read(chanTDC7200* channel) {
   
   digitalWrite(channel->CSB, HIGH);
 
-// read the CLOCK1 register
-    // take the chip select low to select the device:
+  // read the CLOCK1 register
+  // take the chip select low to select the device:
   digitalWrite(channel->CSB, LOW);
 
   SPI.transfer(CLOCK_COUNT1);
@@ -153,8 +143,8 @@ void TDC_read(chanTDC7200* channel) {
   
   digitalWrite(channel->CSB, HIGH);
 
-// read the CALIBRATION1 register
-   // take the chip select low to select the device:
+  // read the CALIBRATION1 register
+  // take the chip select low to select the device:
   digitalWrite(channel->CSB, LOW);
 
   SPI.transfer(CALIBRATION1);
@@ -173,10 +163,9 @@ void TDC_read(chanTDC7200* channel) {
   return;  
 }
 
-
 // Enable next measurement cycle
-void ready_next(chanTDC7200* channel) {
-  // needs to set the enable bit (START_MEAS in CONFIG1)
+void ready_next(struct chanTDC7200 *channel) {
+    // needs to set the enable bit (START_MEAS in CONFIG1)
     writeTDC7200(channel, CONFIG1, 0x03);  // measurement mode 2 ('01')
 }
 
@@ -184,8 +173,7 @@ void ready_next(chanTDC7200* channel) {
 void output_ti() {
 }
 
-void writeTDC7200(chanTDC7200* channel, byte address, byte value) {
-
+void writeTDC7200(struct chanTDC7200 *channel, byte address, byte value) {
   // take the chip select low to select the device:
   digitalWrite(channel->CSB, LOW);
 
@@ -195,11 +183,10 @@ void writeTDC7200(chanTDC7200* channel, byte address, byte value) {
   digitalWrite(channel->CSB, HIGH);
 }
 
-
-byte readTDC7200(chanTDC7200* channel, byte address) {
+byte readTDC7200(struct chanTDC7200 *channel, byte address) {
   byte inByte = 0;
 
-    // take the chip select low to select the device:
+  // take the chip select low to select the device:
   digitalWrite(channel->CSB, LOW);
 
   SPI.transfer(address);
@@ -209,5 +196,3 @@ byte readTDC7200(chanTDC7200* channel, byte address) {
 
   return inByte;
 }
-
-


### PR DESCRIPTION
Here's a PR to make things a little more concrete.  The channels are naturally an array, not separate variables.  This allows you to use loops to iterate them.  Keep in mind that the compiler may very well unroll those loops when there's only two channel items, so it's not a huge performance hit.

What _is_ a performance win is that the code is smaller and more efficient, in addition to being more straight forward to understand.  With Tom's proposed code, the compiler tells me that it's using 3746 bytes in program storage and 281 bytes of global memory.  This version only uses 3560 bytes of program storage and 277 bytes of global memory.  That's a 5% code size reduction.
