### PR TITLE
Reworked SPI access code

### DIFF
--- a/TICC.h
+++ b/TICC.h
@@ -44,8 +44,7 @@ const int CALIBRATION1 =	0x1B;           // default 0x00_0000
 const int CALIBRATION2 =	0x1C;           // default 0x00_0000
 
 // Coarse count interrupt assignments
-const int interrupt =   0x01;		// Interrupt number
-const int intPin =      0x03;		// Interrupt IDE Pin on Mega
+const byte interruptPin =      3;		// Interrupt IDE Pin on Mega
 
 // Channel structure type representing one TDC7200 Channel
 class tdc7200Channel {

--- a/TICC.ino
+++ b/TICC.ino
@@ -32,12 +32,12 @@ void setup() {
   // start the SPI library:
   SPI.begin();
 
-  pinMode(intPin, INPUT);
+  pinMode(interruptPin, INPUT);
 
   for(i = 0; i < ARRAY_SIZE(channels); ++i)
     channels[i].setup();
 
-  attachInterrupt(interrupt, coarseTimer, RISING);
+  attachInterrupt(digitalPinToInterrupt(interruptPin), coarseTimer, RISING);
 
   delay(10);
 


### PR DESCRIPTION
1)  The SPI code needs to be wrapped by a SPI.beginTransaction/endTransaction
    pair for it to work.  Otherwise the SPI layer can't know what the speed
    of the bus is or the SPI mode.  Looked up the speed and SPI mode
    parameters from the TI datasheet.

2)  There is a SPI.transfer(void *, int) method that reads an arbitrary number
    of bytes rather than just one.  This is more efficient than making
    multiple calls to SPI.transfer.  Abstracted this functionality into a
    readReg24 function that will return a 24-bit value from the SPI bus given
    a register.  Note the pointer trickery to start reading into the correct
    byte in the int.

3)  Coaleced the two SPI.transfer(uint8_t) calls in tdc7200Channel::write to
    use a single SPI.transfer16(uint16_t) call for efficiency.
