### PR TITLE
Add platformio.ini to enable building with PlatformIO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,14 @@
+; Before building with PlatformIO, "mkdir lib" and unzip EnableInterrupts.zip
+; inside lib.
+; To build: "pio run"
+; To upload: "pio run -t upload"
+[platformio]
+src_dir = TICC
+lib_dir = lib
+
+[env:mega]
+platform = atmelavr
+framework = arduino
+board = megaatmega2560
+; Uncomment and modify the following line if needed. Default is auto detection.
+; upload_port = /dev/ttyACM0

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,14 +1,12 @@
-; Before building with PlatformIO, "mkdir lib" and unzip EnableInterrupts.zip
-; inside lib.
 ; To build: "pio run"
 ; To upload: "pio run -t upload"
 [platformio]
 src_dir = TICC
-lib_dir = lib
 
 [env:mega]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
+lib_deps = file://./EnableInterrupt.zip
 ; Uncomment and modify the following line if needed. Default is auto detection.
 ; upload_port = /dev/ttyACM0


### PR DESCRIPTION
PlatformIO (platformio.org) is a pretty nice alternative to the Arduino IDE, supporting a commandline mode as well as an Atom-based editor. TICC builds with it without any changes if this config file is provided, so I thought it might be nice to support. PlatformIO also doesn't require any additional "installation" step for the EnableInterrupts library.