### PR TITLE
Fix "missing interrupt" and truncated register reads in TDC7200 driver code

### DIFF
--- a/TICC/tdc7200.cpp
+++ b/TICC/tdc7200.cpp
@@ -227,7 +227,7 @@ uint32_t tdc7200Channel::readReg24(byte address) {
   uint16_t mid = SPI.transfer(0x00);
   uint16_t lsb = SPI.transfer(0x00);
 
-  value = (msb << 16) + (mid << 8) + lsb;
+  value = ((uint32_t)msb << 16) + (mid << 8) + lsb;
 
   digitalWrite(CSB, HIGH);
   SPI.endTransaction();

--- a/TICC/tdc7200.h
+++ b/TICC/tdc7200.h
@@ -82,6 +82,9 @@ public:
   byte readReg8(byte address);
   uint32_t readReg24(byte address);
   void write(byte address, byte value);
+
+private:
+  void tdc_ack_int();
 };
 
 #endif	/* TDC7200_H */


### PR DESCRIPTION
This pull request fixes two bugs in the tdc7200 driver, the first one concerning the missing interrupts for measurement completion, the second one about truncated 24 bit register reads. Please consider merging them with your master branch.